### PR TITLE
Se elimina time

### DIFF
--- a/models/cambio_estado_pago.go
+++ b/models/cambio_estado_pago.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
-
+	
 	"github.com/astaxie/beego/orm"
 )
 


### PR DESCRIPTION
Se elimina 'time' en el modelo ya que no se estaba usando y causaba problemas a la hora de desplegar.